### PR TITLE
fix memory leak in case of connection problems

### DIFF
--- a/grafana_loki_provider/log/loki_task_handler.py
+++ b/grafana_loki_provider/log/loki_task_handler.py
@@ -199,4 +199,8 @@ class LokiTaskHandler(FileTaskHandler, LoggingMixin):
             payload = gzip.compress(json.dumps(payload).encode("utf-8"))
             headers["Content-Encoding"] = "gzip"
 
-        self.hook.push_log(payload=payload, headers=headers)
+        try:
+            self.hook.push_log(payload=payload, headers=headers)
+        except Exception as exception:
+            import traceback
+            logging.getLogger('airflow.task').error(f'error curred while pushing logs to loki {exception}')


### PR DESCRIPTION
I encountered memory leak as can be seen on this screenshot https://stackoverflow.com/questions/67620177/airflow-2-0-issues-too-many-airflow-supervisor-tasks. It turned out that in case of connection problems, if the log cant be pushed, the task hangs silently. Catching exception fixes the problem.